### PR TITLE
fix crash if user has rev share on a release that they didnt publish

### DIFF
--- a/js/sdk/src/contexts/Release/release.js
+++ b/js/sdk/src/contexts/Release/release.js
@@ -1418,16 +1418,18 @@ const releaseContextHelper = ({
     try {
       const { collected } = await NinaSdk.Account.fetchCollected(publicKey, withAccountData)
       const { published } = await NinaSdk.Account.fetchPublished(publicKey, withAccountData)
-      setReleaseState(updateStateForReleases([...collected, ...published]))
+      const { revenueShares } = await NinaSdk.Account.fetchRevenueShares(publicKey, withAccountData)
+      setReleaseState(updateStateForReleases([...collected, ...published, ...revenueShares]))
+      const publishedAndRevenueShares = [...published, ...revenueShares]
       setFetchedUserProfileReleases({
         ...fetchedUserProfileReleases,
         [publicKey]: {
           collected: collected.map((release) => release.publicKey),
-          published: published.map((release) => release.publicKey)
+          published: publishedAndRevenueShares.map((release) => release.publicKey)
         },
       })
   
-      return [collected, published]
+      return [collected, publishedAndRevenueShares]
     } catch (error) {
       console.warn(error)
       return [[],[]]

--- a/js/web/components/Profile.js
+++ b/js/web/components/Profile.js
@@ -241,7 +241,7 @@ const Profile = ({ profilePubkey }) => {
 
       await getSubscriptionsForUser(profilePubkey)
       await getVerificationsForUser(profilePubkey)
-
+        
       let viewIndex
       let updatedView = views.slice()
 


### PR DESCRIPTION
account: http://localhost:3000/profiles/HesfTj24Eatwy8vvra5UdhX1xJWLeqRM7QdDwjX1xmmk

has rev share on a release that they didnt publish - this causes it to not be fetched in Profile.getUserData()

fix: add rev share release fetch to Release.Context.getUserCollectionAndPublished()
[there is probably a more elegant solution to this - thought getUserCollectionAndPublished() has always been a dirty funciton]