### PR TITLE
Text Post Bug

### DIFF
--- a/js/hubs/components/HubPostCreate.js
+++ b/js/hubs/components/HubPostCreate.js
@@ -137,7 +137,7 @@ const HubPostCreate = ({
           : `Create Post`
       );
     }
-  }, [canAddContent, metadataTx, hubData]);
+  }, [metadataTx, hubData]);
 
   const handleFormChange = useCallback(
     async (values) => {
@@ -308,7 +308,6 @@ const HubPostCreate = ({
                         disabled={
                           isPublishing ||
                           !formIsValid ||
-                          !canAddContent ||
                           bundlrBalance === 0 ||
                           mbs < uploadSize
                         }

--- a/js/hubs/components/HubPostCreate.js
+++ b/js/hubs/components/HubPostCreate.js
@@ -56,6 +56,7 @@ const HubPostCreate = ({
     bundlrUpload,
     bundlrBalance,
     getBundlrBalance,
+    bundlrFund,
     bundlrWithdraw,
     getBundlrPricePerMb,
     bundlrPricePerMb,

--- a/js/hubs/components/HubPostCreate.js
+++ b/js/hubs/components/HubPostCreate.js
@@ -41,7 +41,6 @@ const PostCreateSchema = Yup.object().shape({
 const HubPostCreate = ({
   update,
   hubPubkey,
-  // canAddContent,
   hubReleasesToReference,
   preloadedRelease = undefined,
   setParentOpen,
@@ -100,7 +99,7 @@ const HubPostCreate = ({
   }, []);
 
   const refreshBundlr = async () => {
-    await initBundlr()
+    await initBundlr();
     await getBundlrPricePerMb();
     await getBundlrBalance();
     await getSolPrice();
@@ -257,11 +256,6 @@ const HubPostCreate = ({
       }
     }
   };
-
-
-  console.log('formIsValid :>> ', formIsValid);
-  console.log(' mbs < uploadSize :>> ',  mbs < uploadSize);
-  console.log(' canAddContent :>> ',  canAddContent);
 
   return (
     <Root>

--- a/js/hubs/components/HubPostCreate.js
+++ b/js/hubs/components/HubPostCreate.js
@@ -41,7 +41,7 @@ const PostCreateSchema = Yup.object().shape({
 const HubPostCreate = ({
   update,
   hubPubkey,
-  canAddContent,
+  // canAddContent,
   hubReleasesToReference,
   preloadedRelease = undefined,
   setParentOpen,
@@ -53,10 +53,10 @@ const HubPostCreate = ({
   const wallet = useWallet();
   const { postInitViaHub, hubState } = useContext(Hub.Context);
   const {
+    initBundlr,
     bundlrUpload,
     bundlrBalance,
     getBundlrBalance,
-    bundlrFund,
     bundlrWithdraw,
     getBundlrPricePerMb,
     bundlrPricePerMb,
@@ -99,14 +99,15 @@ const HubPostCreate = ({
     refreshBundlr();
   }, []);
 
-  const refreshBundlr = () => {
-    getBundlrPricePerMb();
-    getBundlrBalance();
-    getSolPrice();
+  const refreshBundlr = async () => {
+    await initBundlr()
+    await getBundlrPricePerMb();
+    await getBundlrBalance();
+    await getSolPrice();
   };
 
   useEffect(() => {
-    if (canAddContent) {
+    if (isPublishing) {
       if (!update) {
         if (!metadataTx) {
           setPublishingStepText(
@@ -134,7 +135,7 @@ const HubPostCreate = ({
       setButtonText(
         preloadedRelease
           ? `Create Post on ${hubData?.data.displayName}`
-          : `You do not have permission to create posts`
+          : `Create Post`
       );
     }
   }, [canAddContent, metadataTx, hubData]);
@@ -256,6 +257,11 @@ const HubPostCreate = ({
       }
     }
   };
+
+
+  console.log('formIsValid :>> ', formIsValid);
+  console.log(' mbs < uploadSize :>> ',  mbs < uploadSize);
+  console.log(' canAddContent :>> ',  canAddContent);
 
   return (
     <Root>

--- a/js/hubs/components/NavBar.js
+++ b/js/hubs/components/NavBar.js
@@ -67,6 +67,7 @@ const NavBar = ({ hubPubkey }) => {
     hubCollaboratorsState,
     filterHubCollaboratorsForHub,
     getHub,
+    getHubsForUser
   } = useContext(Hub.Context);
   const hubCollaborators = useMemo(
     () => filterHubCollaboratorsForHub(hubPubkey),
@@ -103,6 +104,13 @@ const NavBar = ({ hubPubkey }) => {
     () => wallet?.publicKey?.toBase58(),
     [wallet?.publicKey]
   );
+
+  useEffect(() => {
+    if (wallet.connected) {
+      console.log('getiching');
+      getHubsForUser(wallet.publicKey.toBase58());
+    }
+  },[wallet.connected])
 
   const walletDisplay = useMemo(() => {
     if (!wallet || !base58) return null;

--- a/js/hubs/components/NavBar.js
+++ b/js/hubs/components/NavBar.js
@@ -107,7 +107,6 @@ const NavBar = ({ hubPubkey }) => {
 
   useEffect(() => {
     if (wallet.connected) {
-      console.log('getiching');
       getHubsForUser(wallet.publicKey.toBase58());
     }
   },[wallet.connected])

--- a/js/sdk/src/contexts/Hub/hub.js
+++ b/js/sdk/src/contexts/Hub/hub.js
@@ -1052,7 +1052,7 @@ const hubContextHelper = ({
           ...hubAccountData,
         }
       })
-      setHubState(updatedHubState)
+      setHubState(prevState => ({...prevState, ...updatedHubState}))
       setHubCollaboratorsState(prevState =>(
         {
           ...prevState,
@@ -1060,7 +1060,6 @@ const hubContextHelper = ({
         }
       ))
       setFetchedHubsForUser(new Set([...fetchedHubsForUser, publicKey]))
-
       return hubs
     } catch (error) {
       console.warn(error)

--- a/js/sdk/src/contexts/Nina/nina.js
+++ b/js/sdk/src/contexts/Nina/nina.js
@@ -712,6 +712,7 @@ const ninaContextHelper = ({
         bundlrInstance = bundlr
       }
       const bundlrBalanceRequest = await bundlrInstance?.getLoadedBalance()
+      console.log('bundlrBalanceRequest :>> ', bundlrBalanceRequest);
       setBundlrBalance(nativeToUi(bundlrBalanceRequest, ids.mints.wsol))
     } catch (error) {
       console.warn('Unable to get Bundlr Balance: ', error)

--- a/js/sdk/src/contexts/Nina/nina.js
+++ b/js/sdk/src/contexts/Nina/nina.js
@@ -712,7 +712,6 @@ const ninaContextHelper = ({
         bundlrInstance = bundlr
       }
       const bundlrBalanceRequest = await bundlrInstance?.getLoadedBalance()
-      console.log('bundlrBalanceRequest :>> ', bundlrBalanceRequest);
       setBundlrBalance(nativeToUi(bundlrBalanceRequest, ids.mints.wsol))
     } catch (error) {
       console.warn('Unable to get Bundlr Balance: ', error)

--- a/js/web/.gitignore
+++ b/js/web/.gitignore
@@ -30,6 +30,8 @@ yarn-error.log*
 .env.development.local
 .env.test.local
 .env.production.local
+.production.local
+.development.local
 
 # vercel
 .vercel

--- a/js/web/components/AddToHubModal.js
+++ b/js/web/components/AddToHubModal.js
@@ -39,7 +39,6 @@ const AddToHubModal = ({ userHubs, releasePubkey, metadata }) => {
       }
       const userHubCollaborations = Object.values(hubCollaboratorsState).filter(
         (collaborator) => {
-          console.log(collaborator)
           return (
             collaborator.canAddContent === true &&
             collaborator.collaborator === wallet.publicKey.toBase58()

--- a/js/web/components/HubPostCreate.js
+++ b/js/web/components/HubPostCreate.js
@@ -41,7 +41,6 @@ const PostCreateSchema = Yup.object().shape({
 const HubPostCreate = ({
   update,
   hubPubkey,
-  canAddContent,
   hubReleasesToReference,
   preloadedRelease,
   selectedHubId,
@@ -58,6 +57,7 @@ const HubPostCreate = ({
     [hubState, hubPubkey, selectedHubId]
   )
   const {
+    initBundlr,
     bundlrUpload,
     bundlrBalance,
     getBundlrBalance,
@@ -98,14 +98,15 @@ const HubPostCreate = ({
     refreshBundlr()
   }, [])
 
-  const refreshBundlr = () => {
-    getBundlrPricePerMb()
-    getBundlrBalance()
-    getSolPrice()
+  const refreshBundlr = async () => {
+    await initBundlr()
+    await getBundlrPricePerMb()
+    await getBundlrBalance()
+    await getSolPrice()
   }
 
   useEffect(() => {
-    if (canAddContent) {
+    if (isPublishing) {
       if (!update) {
         if (!metadataTx) {
           setPublishingStepText(
@@ -133,7 +134,7 @@ const HubPostCreate = ({
       setButtonText(
         preloadedRelease
           ? `Create Post on ${hubData?.data.displayName}`
-          : `You do not have permission to create posts`
+          : `Create Post`
       )
     }
   }, [
@@ -141,7 +142,6 @@ const HubPostCreate = ({
     isPublishing,
     postCreated,
     bundlrBalance,
-    canAddContent,
     hubData,
   ])
 
@@ -268,6 +268,8 @@ const HubPostCreate = ({
     }
   }
 
+  console.log('bundlrBalance :>> ', bundlrBalance);
+
   return (
     <Root>
       <CreateCtaButton
@@ -320,7 +322,7 @@ const HubPostCreate = ({
                         disabled={
                           isPublishing ||
                           !formIsValid ||
-                          (!preloadedRelease && !canAddContent) ||
+                          (!preloadedRelease) ||
                           bundlrBalance === 0 ||
                           mbs < uploadSize
                         }

--- a/js/web/components/HubPostCreate.js
+++ b/js/web/components/HubPostCreate.js
@@ -137,13 +137,7 @@ const HubPostCreate = ({
           : `Create Post`
       )
     }
-  }, [
-    metadataTx,
-    isPublishing,
-    postCreated,
-    bundlrBalance,
-    hubData,
-  ])
+  }, [metadataTx, isPublishing, postCreated, bundlrBalance, hubData])
 
   const handleFormChange = useCallback(
     async (values) => {
@@ -268,8 +262,6 @@ const HubPostCreate = ({
     }
   }
 
-  console.log('bundlrBalance :>> ', bundlrBalance);
-
   return (
     <Root>
       <CreateCtaButton
@@ -322,7 +314,7 @@ const HubPostCreate = ({
                         disabled={
                           isPublishing ||
                           !formIsValid ||
-                          (!preloadedRelease) ||
+                          !preloadedRelease ||
                           bundlrBalance === 0 ||
                           mbs < uploadSize
                         }


### PR DESCRIPTION
- closes #697 
- note: the `canAddContent` that was being driven to enable disable the button was a vestige feature -- now only hubs that the collaborator has permission to add content to are returned and rendered in the select