### PR TITLE
Larger files

### DIFF
--- a/js/hubs/components/MediaDropzone.js
+++ b/js/hubs/components/MediaDropzone.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useContext } from 'react'
 import "react-dropzone-uploader/dist/styles.css";
 import Dropzone from "react-dropzone-uploader";
 import Typography from "@mui/material/Typography";
@@ -6,8 +6,14 @@ import Box from "@mui/material/Box";
 import AddOutlinedIcon from "@mui/icons-material/AddOutlined";
 import ClearOutlinedIcon from "@mui/icons-material/ClearOutlined";
 import Image from "next/image";
+import Nina from '@nina-protocol/nina-internal-sdk/esm/Nina'
 
 const MediaDropzone = ({ type, setArtwork, setTrack, disabled, processingProgress }) => {
+  const {
+    MAX_AUDIO_FILE_UPLOAD_SIZE,
+    MAX_IMAGE_FILE_UPLOAD_SIZE
+  } = useContext(Nina.Context)
+
   const handleChangeStatus = ({ meta, file, remove }, status) => {
     if (meta.status === "error_validation") {
       const height = meta.height;
@@ -15,10 +21,10 @@ const MediaDropzone = ({ type, setArtwork, setTrack, disabled, processingProgres
       const size = meta.size / 1000000;
       if (file.type.includes("audio")) {
         if (file.type !== "audio/mpeg") {
-          alert(`Your track is not an MP3. \nPlease upload an MP3.`);
+          alert(`Your track is not an MP3. \nPlease upload an MP3.`)
         } else {
           alert(
-            `your track is ${size} mb... \nPlease upload a smaller than 500 MBs`
+            `Your track is ${size} mb... \nPlease upload a file smaller than ${MAX_AUDIO_FILE_UPLOAD_SIZE} MBs`
           );
         }
       } else {
@@ -28,7 +34,7 @@ const MediaDropzone = ({ type, setArtwork, setTrack, disabled, processingProgres
           );
         } else {
           alert(
-            `your image is ${size} mb... \nPlease upload an image smaller than 3 MBs`
+            `your image is ${size} mb... \nPlease upload an image smaller than ${MAX_IMAGE_FILE_UPLOAD_SIZE} MBs`
           );
         }
       }
@@ -85,7 +91,7 @@ const MediaDropzone = ({ type, setArtwork, setTrack, disabled, processingProgres
       return true;
     }
 
-    if (size > 8) {
+    if (size > MAX_IMAGE_FILE_UPLOAD_SIZE) {
       return true;
     }
     return false;
@@ -93,7 +99,7 @@ const MediaDropzone = ({ type, setArtwork, setTrack, disabled, processingProgres
 
   const validateTrack = (fileWithMeta) => {
     const size = fileWithMeta.file.size / 1000000;
-    if (size > 500) {
+    if (size > MAX_AUDIO_FILE_UPLOAD_SIZE) {
       return true;
     }
     if (fileWithMeta.file.type !== "audio/mpeg") {

--- a/js/hubs/components/MediaDropzone.js
+++ b/js/hubs/components/MediaDropzone.js
@@ -18,7 +18,7 @@ const MediaDropzone = ({ type, setArtwork, setTrack, disabled, processingProgres
           alert(`Your track is not an MP3. \nPlease upload an MP3.`);
         } else {
           alert(
-            `your track is ${size} mb... \nPlease upload a smaller than 110 mb`
+            `your track is ${size} mb... \nPlease upload a smaller than 500 MBs`
           );
         }
       } else {
@@ -28,7 +28,7 @@ const MediaDropzone = ({ type, setArtwork, setTrack, disabled, processingProgres
           );
         } else {
           alert(
-            `your image is ${size} mb... \nPlease upload an image smaller than 3 mb`
+            `your image is ${size} mb... \nPlease upload an image smaller than 3 MBs`
           );
         }
       }

--- a/js/hubs/components/MediaDropzone.js
+++ b/js/hubs/components/MediaDropzone.js
@@ -7,7 +7,7 @@ import AddOutlinedIcon from "@mui/icons-material/AddOutlined";
 import ClearOutlinedIcon from "@mui/icons-material/ClearOutlined";
 import Image from "next/image";
 
-const MediaDropzone = ({ type, setArtwork, setTrack, disabled }) => {
+const MediaDropzone = ({ type, setArtwork, setTrack, disabled, processingProgress }) => {
   const handleChangeStatus = ({ meta, file, remove }, status) => {
     if (meta.status === "error_validation") {
       const height = meta.height;
@@ -93,7 +93,7 @@ const MediaDropzone = ({ type, setArtwork, setTrack, disabled }) => {
 
   const validateTrack = (fileWithMeta) => {
     const size = fileWithMeta.file.size / 1000000;
-    if (size > 150) {
+    if (size > 500) {
       return true;
     }
     if (fileWithMeta.file.type !== "audio/mpeg") {
@@ -130,6 +130,9 @@ const MediaDropzone = ({ type, setArtwork, setTrack, disabled }) => {
             </Typography>
             <Typography align="left" variant="subtitle1">
               {minutes}:{seconds}
+            </Typography>
+            <Typography align="left" variant="subtitle1">
+              {processingProgress === 1 ? 'Processed' : 'Processing'}: {(processingProgress * 100).toFixed(2)}%
             </Typography>
           </Box>
         </Box>

--- a/js/hubs/components/MediaDropzones.js
+++ b/js/hubs/components/MediaDropzones.js
@@ -12,6 +12,7 @@ const MediaDropzones = ({
   setTrack,
   handleProgress,
   disabled,
+  processingProgress,
 }) => {
   const [metadata, setMetadata] = useState({});
 
@@ -36,6 +37,7 @@ const MediaDropzones = ({
         setTrack={setTrack}
         handleProgress={handleProgress}
         disabled={disabled}
+        processingProgress={processingProgress}
       />
       <label htmlFor="artwork"></label>
       <MediaDropzone

--- a/js/hubs/components/ReleaseCreateViaHub.js
+++ b/js/hubs/components/ReleaseCreateViaHub.js
@@ -93,6 +93,7 @@ const ReleaseCreateViaHub = ({ canAddContent, hubPubkey }) => {
   const [uploadId, setUploadId] = useState();
   const [publishingStepText, setPublishingStepText] = useState();
   const [md5Digest, setMd5Digest] = useState();
+  const [processingProgress, setProcessingProgress] = useState()
 
   const mbs = useMemo(
     () => bundlrBalance / bundlrPricePerMb,
@@ -193,7 +194,7 @@ const ReleaseCreateViaHub = ({ canAddContent, hubPubkey }) => {
   useEffect(() => {
     if (track) {
       const handleGetMd5FileHash = async (track) => {
-        const hash = await getMd5FileHash(track.file);
+        const hash = await getMd5FileHash(track.file, (progress) => setProcessingProgress(progress));
         setMd5Digest(hash);
       };
       handleGetMd5FileHash(track);
@@ -215,7 +216,7 @@ const ReleaseCreateViaHub = ({ canAddContent, hubPubkey }) => {
             hubData.handle
           }/releases/${releaseInfo.hubRelease.toBase58()}`,
         });
-      } else if (track && artwork) {
+      } else if (track && artwork && md5Digest) {
         const error = await checkIfHasBalanceToCompleteAction(
           NinaProgramAction.RELEASE_INIT_VIA_HUB
         );
@@ -369,6 +370,7 @@ const ReleaseCreateViaHub = ({ canAddContent, hubPubkey }) => {
               releasePubkey={releasePubkey}
               track={track}
               disabled={isPublishing || releaseCreated}
+              processingProgress={processingProgress}
             />
           </Box>
 
@@ -436,7 +438,7 @@ const ReleaseCreateViaHub = ({ canAddContent, hubPubkey }) => {
             {bundlrBalance > 0 && !formValuesConfirmed && canAddContent && (
               <ReleaseCreateConfirm
                 formValues={formValues}
-                formIsValid={formIsValid}
+                formIsValid={formIsValid && processingProgress === 1}
                 handleSubmit={(e) => handleSubmit(e)}
                 setFormValuesConfirmed={setFormValuesConfirmed}
               />

--- a/js/sdk/src/contexts/Nina/nina.js
+++ b/js/sdk/src/contexts/Nina/nina.js
@@ -48,6 +48,9 @@ const NinaProgramActionCost = {
   SUBSCRIPTION_SUBSCRIBE_ACCOUNT: 0.00168236,
 }
 
+const MAX_AUDIO_FILE_UPLOAD_SIZE = 500
+const MAX_IMAGE_FILE_UPLOAD_SIZE = 10
+
 const NinaContext = createContext()
 const NinaContextProvider = ({ children, releasePubkey, ninaClient }) => {
   const [collection, setCollection] = useState({})
@@ -251,6 +254,8 @@ const NinaContextProvider = ({ children, releasePubkey, ninaClient }) => {
         submitEmailRequest,
         lowSolBalance,
         getUsdcToSolSwapData,
+        MAX_AUDIO_FILE_UPLOAD_SIZE,
+        MAX_IMAGE_FILE_UPLOAD_SIZE,
       }}
     >
       {children}

--- a/js/sdk/src/utils/index.js
+++ b/js/sdk/src/utils/index.js
@@ -1,7 +1,7 @@
 import * as encrypt from './encrypt'
 import * as web3 from './web3'
 import * as imageManager from './imageManager'
-import MD5 from "crypto-js/md5";
+import CryptoJS from "crypto-js";
 import NinaSdk from "@nina-protocol/js-sdk"
 
 const dateConverter = (date) => {
@@ -82,18 +82,55 @@ const shuffle = (array) => {
   return array;
 }
 
+const readChunked = (file, chunkCallback, endCallback) => {
+  const chunkSize = 1024 * 1024 * 10 // 10MB
+  const fileSize = file.size
+  let offset = 0
 
-const getMd5FileHash = (file) => {
+  let reader = new FileReader()
+  reader.onload = () => {
+    if (reader.error) {
+      console.warn(reader.error)
+      endCallback(reader.error || {})
+      return
+    }
+    offset += reader.result.length
+    chunkCallback(reader.result, offset, fileSize)
+    if (offset >= fileSize) {
+      endCallback()
+      return
+    }
+    readNext()
+  }
+
+  reader.onerror = (err) => {
+    console.warn(err)
+    endCallback(err || {})
+  }
+
+  const readNext = () => {
+    const slice = file.slice(offset, offset + chunkSize)
+    reader.readAsBinaryString(slice)
+  }
+  readNext()
+}
+
+const getMd5FileHash = async (file, progress) => {
   return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-  
-    reader.onload = (e => {
-      const hash = MD5(e.target.result)
-      resolve(hash.toString())
+    let md5 = CryptoJS.algo.MD5.create();
+    readChunked(file, (chunk, offset, total) => {
+      md5 = md5.update(CryptoJS.enc.Latin1.parse(chunk));
+      if (progress) {
+        progress(offset / total)
+      }
+    }, (err) => {
+      if (err) {
+        reject(err)
+      } else {
+        const hash = md5.finalize();
+        resolve(hash.toString())
+      }
     })
-    reader.onerror = (e => reject(e))
-    reader.onabort = (e => reject(e))
-    reader.readAsBinaryString(file)
   })
 }
 

--- a/js/web/components/MediaDropzone.js
+++ b/js/web/components/MediaDropzone.js
@@ -18,7 +18,7 @@ const MediaDropzone = ({ type, setArtwork, setTrack, handleProgress, processingP
           alert(`Your track is not an MP3. \nPlease upload an MP3.`)
         } else {
           alert(
-            `Your track is ${size} mb... \nPlease upload a file smaller than 120 mb`
+            `Your track is ${size} mb... \nPlease upload a file smaller than 500 MBs`
           )
         }
       } else {
@@ -28,7 +28,7 @@ const MediaDropzone = ({ type, setArtwork, setTrack, handleProgress, processingP
           )
         } else {
           alert(
-            `your image is ${size} mb... \nPlease upload an image smaller than 8 mb`
+            `your image is ${size} mb... \nPlease upload an image smaller than 8 MBs`
           )
         }
       }

--- a/js/web/components/MediaDropzone.js
+++ b/js/web/components/MediaDropzone.js
@@ -7,7 +7,7 @@ import AddOutlinedIcon from '@mui/icons-material/AddOutlined'
 import ClearOutlinedIcon from '@mui/icons-material/ClearOutlined'
 import Image from 'next/image'
 
-const MediaDropzone = ({ type, setArtwork, setTrack, handleProgress }) => {
+const MediaDropzone = ({ type, setArtwork, setTrack, handleProgress, processingProgress }) => {
   const handleChangeStatus = ({ file, meta, restart, remove }, status) => {
     if (meta.status === 'error_validation') {
       const height = meta.height
@@ -94,7 +94,7 @@ const MediaDropzone = ({ type, setArtwork, setTrack, handleProgress }) => {
 
   const validateTrack = (fileWithMeta) => {
     const size = fileWithMeta.file.size / 1000000
-    if (size > 150) {
+    if (size > 500) {
       return true
     }
     if (fileWithMeta.file.type !== 'audio/mpeg') {
@@ -133,6 +133,9 @@ const MediaDropzone = ({ type, setArtwork, setTrack, handleProgress }) => {
             </Typography>
             <Typography align="left" variant="subtitle1">
               {minutes}:{seconds}
+            </Typography>
+            <Typography align="left" variant="subtitle1">
+              {processingProgress === 1 ? 'Processed' : 'Processing'}: {(processingProgress * 100).toFixed(2)}%
             </Typography>
           </Box>
         </Box>

--- a/js/web/components/MediaDropzone.js
+++ b/js/web/components/MediaDropzone.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import 'react-dropzone-uploader/dist/styles.css'
 import Dropzone from 'react-dropzone-uploader'
 import Typography from '@mui/material/Typography'
@@ -6,8 +6,14 @@ import Box from '@mui/material/Box'
 import AddOutlinedIcon from '@mui/icons-material/AddOutlined'
 import ClearOutlinedIcon from '@mui/icons-material/ClearOutlined'
 import Image from 'next/image'
+import Nina from '@nina-protocol/nina-internal-sdk/esm/Nina'
 
 const MediaDropzone = ({ type, setArtwork, setTrack, handleProgress, processingProgress }) => {
+  const {
+    MAX_AUDIO_FILE_UPLOAD_SIZE,
+    MAX_IMAGE_FILE_UPLOAD_SIZE
+  } = useContext(Nina.Context)
+
   const handleChangeStatus = ({ file, meta, restart, remove }, status) => {
     if (meta.status === 'error_validation') {
       const height = meta.height
@@ -18,7 +24,7 @@ const MediaDropzone = ({ type, setArtwork, setTrack, handleProgress, processingP
           alert(`Your track is not an MP3. \nPlease upload an MP3.`)
         } else {
           alert(
-            `Your track is ${size} mb... \nPlease upload a file smaller than 500 MBs`
+            `Your track is ${size} mb... \nPlease upload a file smaller than ${MAX_AUDIO_FILE_UPLOAD_SIZE} MBs`
           )
         }
       } else {
@@ -28,7 +34,7 @@ const MediaDropzone = ({ type, setArtwork, setTrack, handleProgress, processingP
           )
         } else {
           alert(
-            `your image is ${size} mb... \nPlease upload an image smaller than 8 MBs`
+            `your image is ${size} mb... \nPlease upload an image smaller than ${MAX_IMAGE_FILE_UPLOAD_SIZE} MBs`
           )
         }
       }
@@ -86,7 +92,7 @@ const MediaDropzone = ({ type, setArtwork, setTrack, handleProgress, processingP
       return true
     }
 
-    if (size > 8) {
+    if (size > MAX_IMAGE_FILE_UPLOAD_SIZE) {
       return true
     }
     return false
@@ -94,7 +100,7 @@ const MediaDropzone = ({ type, setArtwork, setTrack, handleProgress, processingP
 
   const validateTrack = (fileWithMeta) => {
     const size = fileWithMeta.file.size / 1000000
-    if (size > 500) {
+    if (size > MAX_AUDIO_FILE_UPLOAD_SIZE) {
       return true
     }
     if (fileWithMeta.file.type !== 'audio/mpeg') {

--- a/js/web/components/MediaDropzones.js
+++ b/js/web/components/MediaDropzones.js
@@ -11,6 +11,7 @@ const MediaDropzones = ({
   track,
   setTrack,
   handleProgress,
+  processingProgress
 }) => {
   const [metadata, setMetadata] = useState({})
 
@@ -33,6 +34,7 @@ const MediaDropzones = ({
         track={track}
         setTrack={setTrack}
         handleProgress={handleProgress}
+        processingProgress={processingProgress}
       />
       <label htmlFor="artwork"></label>
       <MediaDropzone

--- a/js/web/components/ReleaseCreate.js
+++ b/js/web/components/ReleaseCreate.js
@@ -104,6 +104,7 @@ const ReleaseCreate = () => {
   const [profileHubs, setProfileHubs] = useState()
   const [hubOptions, setHubOptions] = useState()
   const [selectedHub, setSelectedHub] = useState()
+  const [processingProgress, setProcessingProgress] = useState()
   const mbs = useMemo(
     () => bundlrBalance / bundlrPricePerMb,
     [bundlrBalance, bundlrPricePerMb]
@@ -240,7 +241,7 @@ const ReleaseCreate = () => {
   useEffect(() => {
     if (track) {
       const handleGetMd5FileHash = async (track) => {
-        const hash = await getMd5FileHash(track.file)
+        const hash = await getMd5FileHash(track.file, (progress) => setProcessingProgress(progress))
         setMd5Digest(hash)
       }
       handleGetMd5FileHash(track)
@@ -259,7 +260,7 @@ const ReleaseCreate = () => {
           },
           `/${releasePubkey.toBase58()}`
         )
-      } else if (track && artwork) {
+      } else if (track && artwork && md5Digest) {
         const error = await checkIfHasBalanceToCompleteAction(
           NinaProgramAction.RELEASE_INIT_WITH_CREDIT
         )
@@ -423,6 +424,7 @@ const ReleaseCreate = () => {
     } = e
     setSelectedHub(value)
   }
+
   return (
     <Grid item md={12}>
       {!wallet.connected && (
@@ -471,6 +473,7 @@ const ReleaseCreate = () => {
                 track={track}
                 disabled={isPublishing || releaseCreated}
                 handleProgress={handleProgress}
+                processingProgress={processingProgress}
               />
             </Box>
 
@@ -515,7 +518,7 @@ const ReleaseCreate = () => {
               {bundlrBalance > 0 && !formValuesConfirmed && (
                 <ReleaseCreateConfirm
                   formValues={formValues}
-                  formIsValid={formIsValid}
+                  formIsValid={formIsValid && processingProgress === 1}
                   handleSubmit={handleSubmit}
                   setFormValuesConfirmed={setFormValuesConfirmed}
                   artwork={artwork}

--- a/js/web/components/ReleaseCreate.js
+++ b/js/web/components/ReleaseCreate.js
@@ -105,6 +105,7 @@ const ReleaseCreate = () => {
   const [hubOptions, setHubOptions] = useState()
   const [selectedHub, setSelectedHub] = useState()
   const [processingProgress, setProcessingProgress] = useState()
+  
   const mbs = useMemo(
     () => bundlrBalance / bundlrPricePerMb,
     [bundlrBalance, bundlrPricePerMb]


### PR DESCRIPTION
- raise limits on audio files to 500 MB
- use progressive hashing to handle larger files
- display hashing progress in image dropzone + prevent publishing until hashing is complete and hash verification has occurred 