### PR TITLE
Truncate Long Titles with No Whitespace

### DIFF
--- a/js/web/components/ReleaseCard.js
+++ b/js/web/components/ReleaseCard.js
@@ -30,10 +30,10 @@ const ReleaseCard = (props) => {
   const image = useMemo(() => metadata?.image)
   const title = useMemo(() => {
       if (
-        metadata.properties.title.length > 37 &&
+        metadata.properties.title.length > 20 &&
         metadata.properties.title.indexOf(' ') === -1
       ){
-        return metadata.properties.title.substring(0, 37) + '...'
+        return metadata.properties.title.substring(0, 20) + '...'
       }
       return metadata.properties.title
     } , [metadata.properties.title]

--- a/js/web/components/ReleaseCard.js
+++ b/js/web/components/ReleaseCard.js
@@ -28,6 +28,17 @@ const ReleaseCard = (props) => {
   const { updateTrack, addTrackToQueue, isPlaying, setIsPlaying, track } =
     useContext(Audio.Context)
   const image = useMemo(() => metadata?.image)
+  const title = useMemo(() => {
+      if (
+        metadata.properties.title.length > 37 &&
+        metadata.properties.title.indexOf(' ') === -1
+      ){
+        return metadata.properties.title.substring(0, 37) + '...'
+      }
+      return metadata.properties.title
+    } , [metadata.properties.title]
+  )
+
   return (
     <StyledReleaseCard>
       <StyledReleaseInfo>
@@ -83,8 +94,7 @@ const ReleaseCard = (props) => {
               </Link>
               ,{' '}
               <i>
-                {metadata?.properties?.title.substring(0, 100) ||
-                  metadata?.title.substring(0, 100)}
+                {title}
               </i>
             </Typography>
           </Fade>

--- a/js/web/components/ReleaseTileList.js
+++ b/js/web/components/ReleaseTileList.js
@@ -30,6 +30,12 @@ const ReleaseTileList = (props) => {
     <Box>
       <TileGrid>
         {releases.map((release, i) => {
+          if (
+            release.metadata.properties.title.length > 20
+            && release.metadata.properties.title.indexOf(' ') === -1) {
+            release.metadata.properties.title = release.metadata.properties.title.substring(0, 20) + '...'
+          }
+
           return (
             <Tile key={i}>
               <HoverCard
@@ -97,7 +103,7 @@ const ReleaseTileList = (props) => {
               </HoverCard>
               <Box sx={{ padding: '10px 0 0' }}>
                 <ReleaseName>
-                  {release.metadata.name.substring(0, 100)}
+                  {release.metadata.properties.artist} - {release.metadata.properties.title}
                 </ReleaseName>
               </Box>
             </Tile>


### PR DESCRIPTION
- truncate long titles without whitespace that were breaking layout. If there is whitespace, they wrap appropriately