### PR TITLE
improved cropper behavior

### DIFF
--- a/js/sdk/src/components/ImageCropperModal.js
+++ b/js/sdk/src/components/ImageCropperModal.js
@@ -45,7 +45,7 @@ const ImageCropperModal = ({
         croppedAreaPixels,
         rotation
       )
-      
+
       setCroppedImage(croppedImageResult)
       setUncroppedImage(undefined)
     } catch (e) {

--- a/js/sdk/src/components/ImageCropperModal.js
+++ b/js/sdk/src/components/ImageCropperModal.js
@@ -45,6 +45,7 @@ const ImageCropperModal = ({
         croppedAreaPixels,
         rotation
       )
+      console.log('croppedImageResult.size :>> ', croppedImageResult.size);
 
       setCroppedImage(croppedImageResult)
       setUncroppedImage(undefined)

--- a/js/sdk/src/components/ImageCropperModal.js
+++ b/js/sdk/src/components/ImageCropperModal.js
@@ -45,7 +45,7 @@ const ImageCropperModal = ({
         croppedAreaPixels,
         rotation
       )
-
+      
       setCroppedImage(croppedImageResult)
       setUncroppedImage(undefined)
     } catch (e) {

--- a/js/sdk/src/components/ImageCropperModal.js
+++ b/js/sdk/src/components/ImageCropperModal.js
@@ -45,7 +45,6 @@ const ImageCropperModal = ({
         croppedAreaPixels,
         rotation
       )
-      console.log('croppedImageResult.size :>> ', croppedImageResult.size);
 
       setCroppedImage(croppedImageResult)
       setUncroppedImage(undefined)

--- a/js/sdk/src/components/MediaDropzone.js
+++ b/js/sdk/src/components/MediaDropzone.js
@@ -92,7 +92,7 @@ const MediaDropzone = ({
   const handleChangeStatus = useMemo(() => {
     return ({ meta, file, remove }, status) => {
       if (meta.status === 'error_validation') {
-        const size = meta.size / 1000000
+        const size = file.size / 1000000
         if (file.type.includes('audio')) {
           if (file.type !== 'audio/mpeg') {
             alert(`Your track is not an MP3. \nPlease upload an MP3.`)

--- a/js/sdk/src/utils/cropImage.js
+++ b/js/sdk/src/utils/cropImage.js
@@ -87,7 +87,7 @@ export default async function getCroppedImg(
   return new Promise((resolve) => {
     canvas.toBlob(
       (blob) => {
-        resolve(new File([blob], 'fileName.png', { type: 'image/jpeg' }))
+        resolve(new File([blob], 'fileName.png', { type: 'image/png' }))
       },
       'image/jpeg',
       1

--- a/js/sdk/src/utils/cropImage.js
+++ b/js/sdk/src/utils/cropImage.js
@@ -87,7 +87,7 @@ export default async function getCroppedImg(
   return new Promise((resolve) => {
     canvas.toBlob(
       (blob) => {
-        resolve(new File([blob], 'fileName.jpg', { type: 'image/jpeg' }))
+        resolve(new File([blob], 'fileName.png', { type: 'image/jpeg' }))
       },
       'image/jpeg',
       1

--- a/js/sdk/src/utils/cropImage.js
+++ b/js/sdk/src/utils/cropImage.js
@@ -32,7 +32,7 @@ export default async function getCroppedImg(
   imageSrc,
   pixelCrop,
   rotation = 0,
-  flip = { horizontal: false, vertical: false }
+  flip = {horizontal: false, vertical: false}
 ) {
   const image = await createImage(imageSrc)
   const canvas = document.createElement('canvas')
@@ -45,7 +45,7 @@ export default async function getCroppedImg(
   const rotRad = getRadianAngle(rotation)
 
   // calculate bounding box of the rotated image
-  const { width: bBoxWidth, height: bBoxHeight } = rotateSize(
+  const {width: bBoxWidth, height: bBoxHeight} = rotateSize(
     image.width,
     image.height,
     rotation
@@ -60,25 +60,12 @@ export default async function getCroppedImg(
   ctx.rotate(rotRad)
   ctx.scale(flip.horizontal ? -1 : 1, flip.vertical ? -1 : 1)
   ctx.translate(-image.width / 2, -image.height / 2)
-  ctx.imageSmoothingEnabled = false
 
   // draw rotated image
-  ctx.drawImage(
-    image,
-    0,
-    0,
-    image.width,
-    image.height,
-    0,
-    0,
-    image.width,
-    image.height
-  )
+  ctx.drawImage(image, 0, 0)
 
   // croppedAreaPixels values are bounding box relative
   // extract the cropped image using these values
-  ctx.imageSmoothingEnabled = false
-
   const data = ctx.getImageData(
     pixelCrop.x,
     pixelCrop.y,
@@ -89,7 +76,6 @@ export default async function getCroppedImg(
   // set canvas width to final desired crop size - this will clear existing context
   canvas.width = pixelCrop.width
   canvas.height = pixelCrop.height
-  ctx.imageSmoothingEnabled = false
 
   // paste generated rotate image at the top left corner
   ctx.putImageData(data, 0, 0)
@@ -99,13 +85,8 @@ export default async function getCroppedImg(
 
   // As a blob
   return new Promise((resolve) => {
-    canvas.imageSmoothingEnabled = false
-    canvas.toBlob(
-      (blob) => {
-        resolve(new File([blob], 'fileName.png', { type: 'image/png' }))
-      },
-      'image/png',
-      1
-    )
+    canvas.toBlob((blob) => {
+      resolve(new File([blob], 'fileName.jpg', {type: 'image/jpeg'}))
+    }, 'image/jpeg', 1)
   })
 }

--- a/js/sdk/src/utils/cropImage.js
+++ b/js/sdk/src/utils/cropImage.js
@@ -85,12 +85,8 @@ export default async function getCroppedImg(
 
   // As a blob
   return new Promise((resolve) => {
-    canvas.toBlob(
-      (blob) => {
-        resolve(new File([blob], 'fileName.png', { type: 'image/png' }))
-      },
-      'image/png'
-      // 1
-    )
+    canvas.toBlob((blob) => {
+      resolve(new File([blob], 'fileName.png', { type: 'image/png' }))
+    }, 'image/png')
   })
 }

--- a/js/sdk/src/utils/cropImage.js
+++ b/js/sdk/src/utils/cropImage.js
@@ -89,7 +89,7 @@ export default async function getCroppedImg(
       (blob) => {
         resolve(new File([blob], 'fileName.png', { type: 'image/png' }))
       },
-      'image/jpeg',
+      'image/png',
       1
     )
   })

--- a/js/sdk/src/utils/cropImage.js
+++ b/js/sdk/src/utils/cropImage.js
@@ -90,7 +90,7 @@ export default async function getCroppedImg(
         resolve(new File([blob], 'fileName.png', { type: 'image/png' }))
       },
       'image/png',
-      1
+      // 1
     )
   })
 }

--- a/js/sdk/src/utils/cropImage.js
+++ b/js/sdk/src/utils/cropImage.js
@@ -89,7 +89,7 @@ export default async function getCroppedImg(
       (blob) => {
         resolve(new File([blob], 'fileName.png', { type: 'image/png' }))
       },
-      'image/png',
+      'image/png'
       // 1
     )
   })

--- a/js/sdk/src/utils/cropImage.js
+++ b/js/sdk/src/utils/cropImage.js
@@ -32,7 +32,7 @@ export default async function getCroppedImg(
   imageSrc,
   pixelCrop,
   rotation = 0,
-  flip = {horizontal: false, vertical: false}
+  flip = { horizontal: false, vertical: false }
 ) {
   const image = await createImage(imageSrc)
   const canvas = document.createElement('canvas')
@@ -45,7 +45,7 @@ export default async function getCroppedImg(
   const rotRad = getRadianAngle(rotation)
 
   // calculate bounding box of the rotated image
-  const {width: bBoxWidth, height: bBoxHeight} = rotateSize(
+  const { width: bBoxWidth, height: bBoxHeight } = rotateSize(
     image.width,
     image.height,
     rotation
@@ -85,8 +85,12 @@ export default async function getCroppedImg(
 
   // As a blob
   return new Promise((resolve) => {
-    canvas.toBlob((blob) => {
-      resolve(new File([blob], 'fileName.jpg', {type: 'image/jpeg'}))
-    }, 'image/jpeg', 1)
+    canvas.toBlob(
+      (blob) => {
+        resolve(new File([blob], 'fileName.jpg', { type: 'image/jpeg' }))
+      },
+      'image/jpeg',
+      1
+    )
   })
 }


### PR DESCRIPTION
- stops images from being scaled up in imageCropper
- new image rendered by cropper is still slightly larger than original but much closer than current behavior (output is ~0.2mb larger than original)