### PR TITLE
call getUserBalances in hubs releasePurchase

### DIFF
--- a/js/hubs/components/ReleasePurchase.js
+++ b/js/hubs/components/ReleasePurchase.js
@@ -57,6 +57,7 @@ const ReleasePurchase = (props) => {
     checkIfHasBalanceToCompleteAction,
     solBalance,
     NinaProgramAction,
+    getUserBalances,
   } = useContext(Nina.Context)
   const [release, setRelease] = useState(undefined)
   const [userIsRecipient, setUserIsRecipient] = useState(false)
@@ -72,6 +73,10 @@ const ReleasePurchase = (props) => {
     () => releasePurchasePending[releasePubkey],
     [releasePubkey, releasePurchasePending]
   )
+
+  useEffect(() => {
+    getUserBalances()
+  }, [])
 
   const isAuthority = useMemo(() => {
     if (wallet.connected) {

--- a/js/web/components/ReleasePurchase.js
+++ b/js/web/components/ReleasePurchase.js
@@ -137,6 +137,9 @@ const ReleasePurchase = (props) => {
     )
   }, [exchangeState])
 
+
+  console.log('solBalance :>> ', solBalance);
+
   useEffect(() => {
     if (metadata?.descriptionHtml) {
       unified()

--- a/js/web/components/ReleasePurchase.js
+++ b/js/web/components/ReleasePurchase.js
@@ -137,9 +137,6 @@ const ReleasePurchase = (props) => {
     )
   }, [exchangeState])
 
-
-  console.log('solBalance :>> ', solBalance);
-
   useEffect(() => {
     if (metadata?.descriptionHtml) {
       unified()


### PR DESCRIPTION
-closes #1041 

- user balances were not being fetched when landing on a hubRelease page