### PR TITLE
bundlr modal fix for onboarding flow

### DIFF
--- a/js/sdk/src/components/BundlrModal.js
+++ b/js/sdk/src/components/BundlrModal.js
@@ -86,6 +86,7 @@ const BundlrModal = ({
         uploadSize={uploadSize}
         availableSol={availableSol}
         handleClose={handleClose}
+        inOnboardFlow={inOnboardFlow}
       />
     </Root>
   )

--- a/js/sdk/src/components/BundlrModalBody.js
+++ b/js/sdk/src/components/BundlrModalBody.js
@@ -22,6 +22,7 @@ const BundlrModalBody = ({
   showLowUploadModal,
   uploadSize,
   handleClose,
+  inOnboardFlow,
 }) => {
   const { enqueueSnackbar } = useSnackbar()
   const { pendingTransactionMessage } = useContext(Wallet.Context)
@@ -69,7 +70,7 @@ const BundlrModalBody = ({
 
   useEffect(() => {
     const lowSolBalance = releaseCreateFee > formattedSolBalance
-    if (!lowSolBalance) {
+    if (!lowSolBalance || inOnboardFlow) {
       setAmount(0.05)
     }
   }, [releaseCreateFee, formattedSolBalance])

--- a/js/web/components/Onboard.js
+++ b/js/web/components/Onboard.js
@@ -374,6 +374,7 @@ const Onboard = () => {
           info: 'success',
           variant: 'success',
         })
+        await getUserBalances()
         setClaimedError(false)
         setClaimedCodeSuccess(true)
       }

--- a/js/web/components/Onboard.js
+++ b/js/web/components/Onboard.js
@@ -374,7 +374,6 @@ const Onboard = () => {
           info: 'success',
           variant: 'success',
         })
-        await getUserBalances()
         setClaimedError(false)
         setClaimedCodeSuccess(true)
       }


### PR DESCRIPTION
after successfully claiming an onboarding code, the bundlr modal in step 3 of `<Onboard />` defaults its input to a value of 0. additionally, the component failed to refetch the user's SOL balance, causing the bundlr modal deposit to fail.