### PR TITLE
always push verification code redirect to dashboard to finalize onboarding

### DIFF
--- a/js/web/pages/index.js
+++ b/js/web/pages/index.js
@@ -13,7 +13,7 @@ export default function Home() {
       router.push(`/dashboard?code=${router.query.code}`)
     }
   }, [wallet, router, router.query.code])
-  
+
   return (
     <>
       <Head>

--- a/js/web/pages/index.js
+++ b/js/web/pages/index.js
@@ -10,22 +10,10 @@ export default function Home() {
 
   useEffect(() => {
     if (wallet.connected && router?.query?.code) {
-      const inOnboardingFlow = localStorage.getItem('inOnboardingFlow')
-      if (inOnboardingFlow) {
-        const onboardingCode = localStorage.getItem('onboardingCode')
-        localStorage.removeItem('inOnboardingFlow')
-        if (onboardingCode) {
-          router.push(
-            `/start?claim=${onboardingCode}&code=${router.query.code}`
-          )
-        } else {
-          router.push(`/start?code=${router.query.code}`)
-        }
-      } else {
-        router.push(`/dashboard?code=${router.query.code}`)
-      }
+      router.push(`/dashboard?code=${router.query.code}`)
     }
   }, [wallet, router, router.query.code])
+  
   return (
     <>
       <Head>


### PR DESCRIPTION
this pr fixes two issues:

1. users claiming an onboarding code would get stuck on claim code step after verification redirect from soundcloud / twitter 
2. avyss page would redirect to generic onboarding flow and user would get stuck on claim code step

all verification redirects will now take the user to their dashboard to finalize the verification - there are enough CTAs here for verifying more accounts - publishing releases - publishing hubs.

i think this is pretty elegant solution to the above issues