### PR TITLE
Release reopen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "nina"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/programs/nina/Cargo.toml
+++ b/programs/nina/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nina"
-version = "0.2.15"
+version = "0.2.16"
 description = "Nina - A self-publishing protocol"
 edition = "2018"
 

--- a/programs/nina/src/errors.rs
+++ b/programs/nina/src/errors.rs
@@ -76,4 +76,6 @@ pub enum ErrorCode {
     SubscriptionPayerMismatch,
     #[msg("Subscription Delegated Payer Mismatch")]
     SubscriptionDelegatedPayerMismatch,
+    #[msg("Sale Has Stated Already, Cannot Reopen")]
+    ReleaseSaleAlreadyStartedCannotReopen,
 }

--- a/programs/nina/src/instructions/mod.rs
+++ b/programs/nina/src/instructions/mod.rs
@@ -8,6 +8,7 @@ pub mod release_revenue_share_collect_via_hub;
 pub mod release_revenue_share_transfer;
 pub mod release_update_metadata;
 pub mod release_close_edition;
+pub mod release_reopen_edition;
 pub mod release_claim;
 
 pub mod redeemable_init;
@@ -51,6 +52,7 @@ pub use release_revenue_share_collect_via_hub::*;
 pub use release_revenue_share_transfer::*;
 pub use release_update_metadata::*;
 pub use release_close_edition::*;
+pub use release_reopen_edition::*;
 pub use release_claim::*;
 
 pub use redeemable_init::*;

--- a/programs/nina/src/instructions/release_reopen_edition.rs
+++ b/programs/nina/src/instructions/release_reopen_edition.rs
@@ -2,6 +2,7 @@ use anchor_lang::prelude::*;
 use anchor_spl::token::Mint;
 use solana_program::program_option::COption;
 use crate::state::*;
+use crate::errors::ErrorCode;
 
 #[derive(Accounts)]
 pub struct ReleaseReopenEdition<'info> {
@@ -39,9 +40,9 @@ pub fn handler(
         return Err(ErrorCode::ReleaseSaleAlreadyStartedCannotReopen.into());
     }
 
-    release.total_supply = release.amount;
+    release.total_supply = amount;
+    release.remaining_supply = amount;
     release.price = price;
-    release.remaining_supply = 0;
 
     Ok(())
 }

--- a/programs/nina/src/instructions/release_reopen_edition.rs
+++ b/programs/nina/src/instructions/release_reopen_edition.rs
@@ -1,0 +1,47 @@
+use anchor_lang::prelude::*;
+use anchor_spl::token::Mint;
+use solana_program::program_option::COption;
+use crate::state::*;
+
+#[derive(Accounts)]
+pub struct ReleaseReopenEdition<'info> {
+    #[account(mut)]
+    pub authority: Signer<'info>,
+    #[account(
+        mut,
+        seeds = [b"nina-release".as_ref(), release_mint.key().as_ref()],
+        constraint = release.load()?.authority == authority.key(),
+        bump,
+    )]
+    pub release: AccountLoader<'info, Release>,
+    /// CHECK: This is safe because it is derived from release which is checked above
+    #[account(
+        seeds = [release.key().as_ref()],
+        bump,
+    )]
+    pub release_signer: AccountInfo<'info>,
+    #[account(
+        mut,
+        address = release.load()?.release_mint,
+        constraint = release_mint.mint_authority == COption::Some(*release_signer.key),
+    )]
+    pub release_mint: Account<'info, Mint>,
+}
+
+pub fn handler(
+    ctx: Context<ReleaseReopenEdition>,
+    amount: u64,
+    price: u64,
+) -> Result<()> {
+    let mut release = ctx.accounts.release.load_mut()?;
+
+    if release.sale_counter != 0 {
+        return Err(ErrorCode::ReleaseSaleAlreadyStartedCannotReopen.into());
+    }
+
+    release.total_supply = release.amount;
+    release.price = price;
+    release.remaining_supply = 0;
+
+    Ok(())
+}

--- a/programs/nina/src/lib.rs
+++ b/programs/nina/src/lib.rs
@@ -92,6 +92,14 @@ pub mod nina {
         instructions::release_close_edition::handler(ctx)
     }
 
+    pub fn release_reopen_edition(
+        ctx: Context<ReleaseReopenEdition>,
+        amount: u64,
+        price: u64,
+    ) -> Result<()> {
+        instructions::release_reopen_edition::handler(ctx, amount, price)
+    }
+
     pub fn release_claim(
         ctx:Context<ReleaseClaim>,
     ) -> Result<()> {


### PR DESCRIPTION
adds a new instruction to allow reopening a closed edition if no sales have occured.  if a sale has occured a new error `6037:  ReleaseSaleAlreadyStartedCannotReopen` will be thrown.

when reopening you can set/reset `total_supply` and `price`

tests included for this instruction:

![Screenshot 2023-08-08 at 8 53 43 AM](https://github.com/nina-protocol/nina/assets/2960410/fe9894da-42e6-496b-9465-cc5a6d222058)

closes #1108 